### PR TITLE
Add Validator base class

### DIFF
--- a/notary/validator.py
+++ b/notary/validator.py
@@ -1,0 +1,65 @@
+class Validator:
+    def __init__(self, attrs={}, **kwargs):
+        self.errors = {}
+
+        if type(attrs) is dict:
+            for attr in attrs:
+                setattr(self, attr, attrs[attr])
+
+        for attr in kwargs:
+            setattr(self, attr, kwargs[attr])
+
+    def validate(self):
+        raise Exception("You must implement the validate() function in a subclass")
+
+    def is_valid(self):
+        self.errors = {}
+        self.validate()
+
+        return len(self.errors) == 0
+
+    def assert_present(self, attr, message = "not_present"):
+        try:
+            att = getattr(self, attr)
+        except AttributeError:
+            att = None
+
+        if att is None:
+            self._add_error(attr, message)
+            return False
+
+        return True
+
+    def assert_list(self, attr, message="not_valid"):
+        try:
+            lst = getattr(self, attr)
+        except AttributeError:
+            lst = None
+
+        if type(lst) is not list:
+            self._add_error(attr, message)
+
+            return False
+
+        return True
+
+    def assert_not_present(self, attr, message="not_allowed"):
+        try:
+            if getattr(self, attr) is not None:
+                self._add_error(attr, message)
+                return False
+        except AttributeError:
+            pass
+
+        return True
+
+    def assert_in(self, lst, val, message = "{}_not_in_list"):
+        if not val in lst:
+            self._add_error(lst, message.format(val))
+
+    def _add_error(self, attr, error):
+        if self.errors.get(attr) is None:
+            self.errors[attr] = []
+
+        self.errors[attr].append(error)
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+setup(
+    name="data-notary",
+    version="0.1.0",
+    description="Simple data validators for Python",
+    long_description_content_type="text/markdown",
+    url="https://github.com/threefunkymonkeys/data-notary",
+    author="Three Funky Monkeys",
+    author_email="kandalf@threefunkymonkeys.com",
+    license="MIT",
+    packages=["notary"]
+)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,76 @@
+import unittest
+
+from notary.validator import Validator
+
+class UserValidator(Validator):
+    def validate(self):
+        self.assert_present("email")
+        self.assert_present("name", message = "Name is not present")
+
+        self.assert_list("phone_numbers")
+        self.assert_list("addresses", message = "Addresses is not a list")
+
+        self.assert_not_present("middle_name")
+        self.assert_not_present("age", message = "Age is not allowed")
+
+        self.assert_in("identifications", "Passport")
+
+class TestValidator(unittest.TestCase):
+    def test_presence(self):
+        attrs = { "last_name": "Staley" }
+
+        validator = UserValidator(**attrs)
+
+        self.assertFalse(validator.is_valid())
+        self.assertEqual(validator.errors["email"], ["not_present"])
+        self.assertEqual(validator.errors["name"], ["Name is not present"])
+
+    def test_no_presence(self):
+        attrs = {
+            "first_name": "Layne",
+            "middle_name": "Thomas",
+            "last_name": "Staley",
+            "email": "layne@aic.com",
+            "phone_numbers": "(555) 555-5555, (222) 222-2222",
+            "addresses": "123 Some St",
+            "age": 34
+        }
+
+        validator = UserValidator(**attrs)
+
+        self.assertFalse(validator.is_valid())
+        self.assertEqual(validator.errors["middle_name"], ["not_allowed"])
+        self.assertEqual(validator.errors["age"], ["Age is not allowed"])
+
+    def test_list(self):
+        attrs = {
+            "first_name": "Layne",
+            "last_name": "Staley",
+            "email": "layne@aic.com",
+            "phone_numbers": "(555) 555-5555, (222) 222-2222",
+            "addresses": "123 Some St"
+        }
+
+        validator = UserValidator(**attrs)
+
+        self.assertFalse(validator.is_valid())
+        self.assertEqual(validator.errors["phone_numbers"], ["not_valid"])
+        self.assertEqual(validator.errors["addresses"], ["Addresses is not a list"])
+
+    def test_in_list(self):
+        attrs = {
+            "first_name": "Layne",
+            "last_name": "Staley",
+            "email": "layne@aic.com",
+            "phone_numbers": "(555) 555-5555, (222) 222-2222",
+            "addresses": "123 Some St",
+            "identifications": ["Driver's License", "Government ID"]
+        }
+
+        validator = UserValidator(**attrs)
+
+        self.assertFalse(validator.is_valid())
+        self.assertEqual(validator.errors["identifications"], ["Passport_not_in_list"])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds the `Validator` base class to implement data validators.

In order to implement your validators, you need to subclass `notary.Validator` and add your custom validations (and potentially, custom messages as well).

Take a look at the tests/test_validator.py for a better reference:
```Python
class UserValidator(Validator):
    def validate(self):
        self.assert_present("email")
        self.assert_present("name", message = "Name is not present")

        self.assert_list("phone_numbers")
        self.assert_list("addresses", message = "Addresses is not a list")

        self.assert_not_present("middle_name")
        self.assert_not_present("age", message = "Age is not allowed")

        self.assert_in("identifications", "Passport")
```