### PR TITLE
Support undefined attributes

### DIFF
--- a/notary/validator.py
+++ b/notary/validator.py
@@ -1,4 +1,4 @@
-class Validator:
+class Validator(object):
     def __init__(self, attrs={}, **kwargs):
         self.errors = {}
 
@@ -8,6 +8,12 @@ class Validator:
 
         for attr in kwargs:
             setattr(self, attr, kwargs[attr])
+
+    def __getattr__(self, name):
+        def _missing(*args, **kwargs):
+            return None
+
+        return _missing()
 
     def validate(self):
         raise Exception("You must implement the validate() function in a subclass")

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -16,6 +16,13 @@ class UserValidator(Validator):
         self.assert_in("identifications", "Passport")
 
 class TestValidator(unittest.TestCase):
+    def test_undefined_attribute(self):
+        attrs = { "last_name": "Staley" }
+
+        validator = UserValidator(**attrs)
+
+        self.assertIsNone(validator.first_name)
+
     def test_presence(self):
         attrs = { "last_name": "Staley" }
 


### PR DESCRIPTION
This PR supports undefined attributes in `Validator` class so it returns `None` instead of raising an `AttributeError` exception.