### PR TITLE
Fix assert in list bug

### DIFF
--- a/notary/validator.py
+++ b/notary/validator.py
@@ -59,9 +59,15 @@ class Validator(object):
 
         return True
 
-    def assert_in(self, lst, val, message = "{}_not_in_list"):
+    def assert_in(self, attr, val, message = "{}_not_in_list"):
+        lst = getattr(self, attr)
+
+        if type(lst) is not list:
+            self._add_error(lst, "not_valid")
+            return
+
         if not val in lst:
-            self._add_error(lst, message.format(val))
+            self._add_error(attr, message.format(val))
 
     def _add_error(self, attr, error):
         if self.errors.get(attr) is None:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -17,14 +17,16 @@ class UserValidator(Validator):
 
 class TestValidator(unittest.TestCase):
     def test_undefined_attribute(self):
-        attrs = { "last_name": "Staley" }
+        attrs = { "last_name": "Staley",
+                  "identifications": ["Driver's License", "Government ID"] }
 
         validator = UserValidator(**attrs)
 
         self.assertIsNone(validator.first_name)
 
     def test_presence(self):
-        attrs = { "last_name": "Staley" }
+        attrs = { "last_name": "Staley",
+                  "identifications": ["Driver's License", "Government ID"] }
 
         validator = UserValidator(**attrs)
 


### PR DESCRIPTION
This PR fixes a bug in the `assert_in` matcher that was expected the actual value of the list instead of the attribute name to be consistent with the other matchers.

It also caused an exception when trying to serialize the list in the `_add_error` method